### PR TITLE
Add the ability to change the T-Digest allocator at compile time.

### DIFF
--- a/src/td_malloc.h
+++ b/src/td_malloc.h
@@ -1,0 +1,20 @@
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * The implementation is a direct descendent of MergingDigest
+ * https://github.com/tdunning/t-digest/
+ *
+ * Copyright (c) 2021 Filipe Oliveira, All rights reserved.
+ *
+ * Allocator selection.
+ *
+ * This file is used in order to change the t-digest allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#ifndef TD_ALLOC_H
+#define TD_ALLOC_H
+#define __td_malloc malloc
+#define __td_realloc realloc
+#define __td_free free
+#endif

--- a/src/td_malloc.h
+++ b/src/td_malloc.h
@@ -3,7 +3,7 @@
  * The implementation is a direct descendent of MergingDigest
  * https://github.com/tdunning/t-digest/
  *
- * Copyright (c) 2021 Filipe Oliveira, All rights reserved.
+ * Copyright (c) 2021 Redis Labs, All rights reserved.
  *
  * Allocator selection.
  *

--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -4,6 +4,12 @@
 #include <math.h>
 #include "tdigest.h"
 
+#ifndef TD_MALLOC_INCLUDE
+#define TD_MALLOC_INCLUDE "td_malloc.h"
+#endif
+
+#include TD_MALLOC_INCLUDE
+
 void bbzero(void *to, size_t count) { memset(to, 0, count); }
 
 static bool is_very_small(double val) { return !(val > .000000001 || val < -.000000001); }
@@ -56,10 +62,10 @@ static td_histogram_t *td_init(double compression, size_t buf_size, char *buf) {
 
 td_histogram_t *td_new(double compression) {
     size_t memsize = td_required_buf_size(compression);
-    return td_init(compression, memsize, (char *)(malloc(memsize)));
+    return td_init(compression, memsize, (char *)(__td_malloc(memsize)));
 }
 
-void td_free(td_histogram_t *h) { free((void *)(h)); }
+void td_free(td_histogram_t *h) { __td_free((void *)(h)); }
 
 void td_merge(td_histogram_t *into, td_histogram_t *from) {
     td_compress(into);

--- a/src/tdigest.h
+++ b/src/tdigest.h
@@ -6,6 +6,7 @@
  * The implementation is a direct descendent of MergingDigest
  * https://github.com/tdunning/t-digest/
  *
+ * Copyright (c) 2021 Redis Labs, All rights reserved.
  * Copyright (c) 2018 Andrew Werner, All rights reserved.
  *
  * The special characteristics of this algorithm are:


### PR DESCRIPTION
This PR adds the ability to change the T-Digest allocator at compile time. 

The `td_malloc.h`  file is used in order to change the T-Digest allocator at compile time.
To alter the allocator just alter the following defines to what you want to use in `td_malloc.h`
```
#define __td_malloc malloc
#define __td_calloc calloc
#define __td_realloc realloc
#define __td_free free
```
Also add the include of your alternate allocator if needed (not needed in order to use the default libc allocator).