### PR TITLE
support for older OSes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - checkout
       - run:
           name: Install CMAKE
-          command: 'apt install -y cmake'
+          command: 'apt update -q && apt install -y cmake'
       - run:
           name: Pull Submodules
           command: git submodule update --init --recursive
@@ -43,7 +43,7 @@ jobs:
   build:
     docker:
       - image: "debian:stretch"
-    steps:  
+    steps:
       - run:
           name: Installing SUDO
           command: 'apt update && apt install -y sudo && rm -rf /var/lib/apt/lists/*'
@@ -78,7 +78,7 @@ jobs:
 workflows:
   commit:
     jobs:
-      - lint 
+      - lint
       - build
       - sanitize
   nightly:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ ENDIF()
 # Generate position-independent code (-fPIC on UNIX)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -std=c99")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -std=c99")
 
 if(ENABLE_PROFILE)
   message(STATUS "Enabling profile flags.")
@@ -85,7 +85,7 @@ include(GNUInstallDirs)
 add_subdirectory("src")
 
 # --- Documentation ---
-# TODO 
+# TODO
 
 # --- Unit Tests ---
 ENABLE_TESTING()


### PR DESCRIPTION
Compiler flag to enable initial declarations. In older compilers C99 mode was not automatic.