### PR TITLE
Added td_quantiles() API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,10 @@ bench: clean
 	( mkdir -p build; cd build ; cmake $(CMAKE_BENCHMARK_OPTIONS) .. ; $(MAKE) VERBOSE=1 )
 	$(SHOW) build/tests/histogram_benchmark --benchmark_min_time=10
 
+bench-quantile: clean
+	( mkdir -p build; cd build ; cmake $(CMAKE_BENCHMARK_OPTIONS) .. ; $(MAKE) VERBOSE=1 )
+	$(SHOW) build/tests/histogram_benchmark  --benchmark_min_time=10 --benchmark_filter="BM_td_quantile_lognormal_dist_given_array*|BM_td_quantiles_*"
+
 perf-stat-bench:
 	( mkdir -p build; cd build ; cmake $(CMAKE_PROFILE_OPTIONS) .. ; $(MAKE) VERBOSE=1 )
 	$(SHOW) perf stat build/tests/histogram_benchmark --benchmark_min_time=10

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following functions are implemented:
   - `td_merge`: Merge one t-Digest into another
   - `td_cdf`:  Returns the fraction of all points added which are &le; x.
   - `td_quantile`: Returns an estimate of the cutoff such that a specified fraction of the data added to the t-Digest would be less than or equal to the cutoff.
+  - `td_quantiles`: Returns an estimate of the cutoff such that a specified fraction of the data added to the t-Digest would be less than or equal to the given cutoffs.
   - `td_size`: Return the number of points that have been added to the t-Digest
   - `td_centroid_count`: Return the number of centroids being used by the t-Digest
   - `td_min`: Get the minimum value from the histogram.  Will return __DBL_MAX__ if the histogram is empty

--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -403,7 +403,7 @@ int td_quantiles(td_histogram_t *h, const double *quantiles, double *values, siz
             const double requested_quantile = quantiles[i];
 
             // q should be in [0,1]
-            if (requested_quantile < 0.0 || requested_quantile > 1.0 || h->merged_nodes == 0) {
+            if (requested_quantile < 0.0 || requested_quantile > 1.0) {
                 values[i] = NAN;
             } else {
                 // with one data point, all quantiles lead to Rome

--- a/src/tdigest.h
+++ b/src/tdigest.h
@@ -144,6 +144,17 @@ double td_cdf(td_histogram_t *h, double x);
 double td_quantile(td_histogram_t *h, double q);
 
 /**
+ * Returns an estimate of the cutoff such that a specified fraction of the data
+ * added to this TDigest would be less than or equal to the cutoffs.
+ *
+ * @param quantiles The ordered percentiles array to get the values for.
+ * @param values Destination array containing the values at the given quantiles.
+ * The values array should be allocated by the caller.
+ * @return 0 on success, ENOMEM if the provided destination array is null.
+ */
+int td_quantiles(td_histogram_t *h, const double *quantiles, double *values, size_t length);
+
+/**
  * Returns the trimmed mean ignoring values outside given cutoff upper and lower limits.
  *
  * @param leftmost_cut Fraction to cut off of the left tail of the distribution.

--- a/tests/unit/td_test.c
+++ b/tests/unit/td_test.c
@@ -493,7 +493,7 @@ MU_TEST(test_quantiles_multiple) {
     mu_assert_double_eq_epsilon(9.999, values[11], 0.01);
     mu_assert_double_eq_epsilon(9.9999, values[12], 0.01);
     mu_assert_double_eq_epsilon(10.0, values[13], 0.001);
-
+    td_free(histogram);
     td_histogram_t *t = td_new(100);
     mu_assert(td_quantiles(t, percentiles, values, quantiles_arr_size) == 0,
               "td_quantiles return should be 0");
@@ -515,6 +515,7 @@ MU_TEST(test_quantiles_multiple) {
     for (int i = 0; i < quantiles_arr_size; ++i) {
         mu_assert(isnan(values[i]), " q should be in [0,1]");
     }
+    td_free(t);
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/tests/unit/td_test.c
+++ b/tests/unit/td_test.c
@@ -432,6 +432,23 @@ MU_TEST(test_td_min) {
     mu_assert_double_eq_epsilon(0.0, td_min(histogram), 0.001);
 }
 
+bool compare_double(double a, double b, double delta) {
+    if (fabs(a - b) < delta) {
+        return true;
+    }
+
+    printf("[compare_double] fabs(%f, %f) < %f == false\n", a, b, delta);
+    return false;
+}
+
+static bool compare_values(double a, double b, double variation) {
+    return compare_double(a, b, b * variation);
+}
+
+static bool compare_percentile(int64_t a, double b, double variation) {
+    return compare_values((double)a, b, variation);
+}
+
 MU_TEST(test_quantiles) {
     load_histograms();
     mu_assert_double_eq_epsilon(0.0, td_quantile(histogram, 0.0), 0.001);
@@ -450,6 +467,56 @@ MU_TEST(test_quantiles) {
     mu_assert_double_eq_epsilon(10.0, td_quantile(histogram, 1.0), 0.001);
 }
 
+MU_TEST(test_quantiles_multiple) {
+    load_histograms();
+    const size_t quantiles_arr_size = 14;
+    double values[14] = {0.0};
+    double percentiles[14] = {0.0, 0.1, 0.2, 0.3,   0.4,    0.5,     0.6,
+                              0.7, 0.8, 0.9, 0.999, 0.9999, 0.99999, 1.0};
+    mu_assert(td_quantiles(histogram, NULL, values, quantiles_arr_size) == EINVAL,
+              "td_quantiles on NULL percentiles should return EINVAL");
+    mu_assert(td_quantiles(histogram, percentiles, NULL, quantiles_arr_size) == EINVAL,
+              "td_quantiles on NULL values should return EINVAL");
+    mu_assert(td_quantiles(histogram, percentiles, values, quantiles_arr_size) == 0,
+              "td_quantiles return should be 0");
+    mu_assert_double_eq_epsilon(0.0, values[0], 0.001);
+    mu_assert_double_eq_epsilon(1.0, values[1], 0.02);
+    mu_assert_double_eq_epsilon(2.0, values[2], 0.02);
+    mu_assert_double_eq_epsilon(3.0, values[3], 0.03);
+    mu_assert_double_eq_epsilon(4.0, values[4], 0.04);
+    mu_assert_double_eq_epsilon(5.0, values[5], 0.05);
+    mu_assert_double_eq_epsilon(6.0, values[6], 0.04);
+    mu_assert_double_eq_epsilon(7.0, values[7], 0.03);
+    mu_assert_double_eq_epsilon(8.0, values[8], 0.02);
+    mu_assert_double_eq_epsilon(9.0, values[9], 0.02);
+    mu_assert_double_eq_epsilon(9.99, values[10], 0.01);
+    mu_assert_double_eq_epsilon(9.999, values[11], 0.01);
+    mu_assert_double_eq_epsilon(9.9999, values[12], 0.01);
+    mu_assert_double_eq_epsilon(10.0, values[13], 0.001);
+
+    td_histogram_t *t = td_new(100);
+    mu_assert(td_quantiles(t, percentiles, values, quantiles_arr_size) == 0,
+              "td_quantiles return should be 0");
+    for (int i = 0; i < quantiles_arr_size; ++i) {
+        mu_assert(isnan(values[i]), "no data to examine");
+    }
+    td_add(t, 1, 1);
+    // with one data point, all quantiles lead to Rome
+    mu_assert(td_quantiles(t, percentiles, values, quantiles_arr_size) == 0,
+              "td_quantiles return should be 0");
+    for (int i = 0; i < quantiles_arr_size; ++i) {
+        mu_assert_double_eq_epsilon(1.0, values[i], 0.02);
+    }
+    // q should be in [0,1]
+    double percentiles_nans[14] = {-10.0, 10.1, 10.2, 10.3,   10.4,    10.5,     10.6,
+                                   10.7,  10.8, 10.9, -0.999, -0.9999, -0.99999, -1.0};
+    mu_assert(td_quantiles(t, percentiles_nans, values, quantiles_arr_size) == 0,
+              "td_quantiles return should be 0");
+    for (int i = 0; i < quantiles_arr_size; ++i) {
+        mu_assert(isnan(values[i]), " q should be in [0,1]");
+    }
+}
+
 MU_TEST_SUITE(test_suite) {
     MU_RUN_TEST(test_basic);
     MU_RUN_TEST(test_compress_small);
@@ -464,6 +531,7 @@ MU_TEST_SUITE(test_suite) {
     MU_RUN_TEST(test_td_max);
     MU_RUN_TEST(test_td_min);
     MU_RUN_TEST(test_quantiles);
+    MU_RUN_TEST(test_quantiles_multiple);
     MU_RUN_TEST(test_trimmed_mean_simple);
     MU_RUN_TEST(test_trimmed_mean_complex);
 }


### PR DESCRIPTION
This new API `td_quantiles` implies a 7% reduction of the total CPU cycles to calculate a set of 4 quantiles that we normally use for monitoring. 

Fixes #17 


```
build/tests/histogram_benchmark  --benchmark_min_time=10 --benchmark_filter="BM_td_quantile_lognormal_dist_given_array*|BM_td_quantiles_*"
2022-05-20T16:09:43+00:00
Running build/tests/histogram_benchmark
Run on (20 X 913.345 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x20)
  L1 Instruction 32 KiB (x20)
  L2 Unified 1024 KiB (x20)
  L3 Unified 28160 KiB (x1)
Load Average: 0.32, 0.10, 0.02
------------------------------------------------------------------------------------------------------------------
Benchmark                                                        Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------
BM_td_quantile_lognormal_dist_given_array/100/10000000        92.0 ns         92.0 ns    151836516 Centroid_Count=70 Total_Compressions=18.461k items_per_second=715.78k/s
BM_td_quantile_lognormal_dist_given_array/200/10000000        92.1 ns         92.1 ns    152326099 Centroid_Count=115 Total_Compressions=9.131k items_per_second=712.997k/s
BM_td_quantile_lognormal_dist_given_array/300/10000000        92.1 ns         92.1 ns    152056453 Centroid_Count=163 Total_Compressions=6.066k items_per_second=714.23k/s
BM_td_quantile_lognormal_dist_given_array/400/10000000        92.1 ns         92.0 ns    152101891 Centroid_Count=210 Total_Compressions=4.535k items_per_second=714.237k/s
BM_td_quantile_lognormal_dist_given_array/500/10000000        92.1 ns         92.1 ns    151949891 Centroid_Count=248 Total_Compressions=3.618k items_per_second=714.726k/s
BM_td_quantiles_lognormal_dist_given_array/100/10000000       85.5 ns         85.4 ns    164029880 Centroid_Count=70 Total_Compressions=18.461k items_per_second=713.47k/s
BM_td_quantiles_lognormal_dist_given_array/200/10000000       85.3 ns         85.3 ns    164011596 Centroid_Count=115 Total_Compressions=9.131k items_per_second=714.423k/s
BM_td_quantiles_lognormal_dist_given_array/300/10000000       85.3 ns         85.3 ns    164121590 Centroid_Count=163 Total_Compressions=6.066k items_per_second=713.966k/s
BM_td_quantiles_lognormal_dist_given_array/400/10000000       85.4 ns         85.4 ns    164214797 Centroid_Count=210 Total_Compressions=4.535k items_per_second=713.202k/s
BM_td_quantiles_lognormal_dist_given_array/500/10000000       85.4 ns         85.4 ns    163643996 Centroid_Count=248 Total_Compressions=3.618k items_per_second=715.744k/s
```
