### PR TITLE
Fixed td_quantile returning NaN when 1 sample

### DIFF
--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -412,11 +412,11 @@ static double td_internal_iterate_centroids_to_index(const td_histogram_t *h, co
 double td_quantile(td_histogram_t *h, double q) {
     td_compress(h);
     // q should be in [0,1]
-    if (q < 0.0 || q > 1.0 || h->merged_nodes == 0) {
+    if (q < 0.0 || q > 1.0 || h->merged_nodes + h->unmerged_nodes == 0) {
         return NAN;
     }
     // with one data point, all quantiles lead to Rome
-    if (h->merged_nodes == 1) {
+    if (h->merged_nodes + h->unmerged_nodes == 1) {
         return h->nodes_mean[0];
     }
 


### PR DESCRIPTION
When the t-digest has only a single sample, td_quantile returns NaN when it should return the value of the single sample.

The problem is that td_compress does not update the merged_nodes counter when there is only a single value. 

Fix is to check on (merged_nodes + unmerged_nodes)

Steps to reproduce:

#include <cmocka.h>

td_histogram_t *h = td_new(50.0);
td_add(h, 0.2, 1);
assert_true(td_quantile(h, 0.5) == 0.2);