### PR TITLE
Fix CMake minimum version requirement for modern CMake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ## cmake flags
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 project(tdigest)
 
 # CMake modules should be included in ${CMAKE_SOURCE_DIR}/cmake


### PR DESCRIPTION
Update cmake_minimum_required from 3.0 to 3.10 to fix build failures on macOS CI runners. Modern CMake versions (4.x) have removed support for CMake < 3.5, causing configuration errors.

This change ensures compatibility with current CMake versions while maintaining backward compatibility with CMake 3.10+.