### PR TITLE
Fix NULL pointer crash in td_free function

### DIFF
--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -191,6 +191,9 @@ td_histogram_t *td_new(double compression) {
 }
 
 void td_free(td_histogram_t *histogram) {
+    if (!histogram) {
+        return;
+    }
     if (histogram->nodes_mean) {
         td_free_((void *)(histogram->nodes_mean));
     }


### PR DESCRIPTION
- Add NULL check at the beginning of td_free to prevent segmentation fault
- This fixes crashes when td_init fails and calls td_free with NULL pointer
- Resolves issue where Redis server crashes instead of returning proper error

The bug was causing Redis server crashes in Ubuntu ARM Focal when memory allocation failed during t-digest operations, particularly in tests like test_insufficient_memory that expect proper error handling instead of server crashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a NULL check to `td_free` to avoid dereferencing a null histogram pointer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d300bd1a6f5195a3c15e404d7cb434322225f342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->