### PR TITLE
Fix allocation

### DIFF
--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -166,6 +166,8 @@ int td_init(double compression, td_histogram_t **result) {
     if (!histogram) {
         return 1;
     }
+    histogram->nodes_mean = NULL;
+    histogram->nodes_weight = NULL;
     histogram->cap = capacity;
     histogram->compression = (double)compression;
     td_reset(histogram);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Initialize `nodes_mean` and `nodes_weight` to `NULL` in `td_init` to ensure safe cleanup on allocation failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43e8248354048820559648fb2c6270fa845294e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->