### PR TITLE
MOD-13821 Fix compression with total_weight=1

### DIFF
--- a/src/tdigest.c
+++ b/src/tdigest.c
@@ -608,8 +608,17 @@ int td_compress(td_histogram_t *h) {
     const int overflow_res = _check_td_overflow((double)h->unmerged_weight, (double)total_weight);
     if (overflow_res != 0)
         return overflow_res;
-    if (total_weight <= 1)
+    if (total_weight <= 1) {
+        // Only move data if there are unmerged nodes to move
+        if (h->unmerged_nodes > 0) {
+            h->merged_nodes = h->merged_nodes + h->unmerged_nodes;
+            h->merged_weight = total_weight;
+            h->unmerged_nodes = 0;
+            h->unmerged_weight = 0;
+            h->total_compressions++;
+        }
         return 0;
+    }
     const double denom = 2 * MM_PI * total_weight * log(total_weight);
     if (_check_overflow(denom) != 0)
         return EDOM;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core `tdigest` compression behavior and changes how single-sample/low-weight histograms transition from unmerged to merged state, which can affect downstream quantile/CDF results.
> 
> **Overview**
> Fixes an edge case in `td_compress` where `total_weight<=1` would previously return early without promoting `unmerged_*` data into the merged centroids.
> 
> When this condition is hit, the function now moves unmerged nodes/weight into `merged_nodes`/`merged_weight`, clears the unmerged counters, and increments `total_compressions`, avoiding inconsistent histogram state for single-point (or extremely low-weight) inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f7985665ead1198cf2113b285ad2018122c7d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->